### PR TITLE
Update inkscape build instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ out.zip: $(FILES)
 
 # There's no good way to avoid duplicating the recipe here.
 images/audible-dark-%.png: images/audible.svg
-	inkscape -z -e $@ -w $* -h $* $<
+	inkscape -z -o $@ -w $* -h $* $<
 images/muted-dark-%.png: images/muted.svg
-	inkscape -z -e $@ -w $* -h $* $<
+	inkscape -z -o $@ -w $* -h $* $<
 
 images/audible-light-%.png: images/audible-dark-%.png
 	convert $< -negate $@

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ ICONS := $(addprefix images/, $(addsuffix .png, $(ICONNAMES)))
 
 FILES := $(ICONS) $(shell git ls-files ':!:.gitignore' ':!:Makefile' ':!:images/' ':!:release.sh')
 
+# inkscape >1.0 deprecates the -z (without-gui) flag and dropped
+# support for the -e (export-filename) flag.
+# TODO: stderr is redirected due to
+# https://gitlab.com/inkscape/inbox/-/issues/3882; remove stderr
+# redirection when resolved upstream.
+INKSCAPE_EXPORT_FLAG := $(shell if inkscape --version 2> /dev/null | grep -qF "Inkscape 0."; then printf %s "-z -e"; else printf %s -o; fi)
+
 .PHONY: zip
 zip: out.zip
 
@@ -13,9 +20,9 @@ out.zip: $(FILES)
 
 # There's no good way to avoid duplicating the recipe here.
 images/audible-dark-%.png: images/audible.svg
-	inkscape -z -o $@ -w $* -h $* $<
+	inkscape $(INKSCAPE_EXPORT_FLAG) $@ -w $* -h $* $<
 images/muted-dark-%.png: images/muted.svg
-	inkscape -z -o $@ -w $* -h $* $<
+	inkscape $(INKSCAPE_EXPORT_FLAG) $@ -w $* -h $* $<
 
 images/audible-light-%.png: images/audible-dark-%.png
 	convert $< -negate $@


### PR DESCRIPTION
This patch updates the inkscape build instructions to the latest version of inkscape available through Homebrew, which no longer supports the option `-e`:

```
λ brew info inkscape
brewinkscape: 1.0.2
https://inkscape.org/
/usr/local/Caskroom/inkscape/1.0.2 (2 files, 772KB)
From: https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/inkscape.rb
==> Name
Inkscape
==> Description
Vector graphics editor
==> Artifacts
Inkscape.app (App)
/usr/local/Caskroom/inkscape/1.0.2/inkscape.wrapper.sh -> inkscape (Binary)
^R
==> Analytics
install: 2,133 (30 days), 5,861 (90 days), 25,983 (365 days)

~
λ inkscape --version
Inkscape 1.0.2 (e86c8708, 2021-01-15)
    Pango version: 1.43.0

~
λ inkscape -e
Unknown option -e
```